### PR TITLE
fix thread-locals and FileInputStream finalizers

### DIFF
--- a/src/main/java/net/shipilev/dedup/Main.java
+++ b/src/main/java/net/shipilev/dedup/Main.java
@@ -95,9 +95,8 @@ public class Main {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (!attrs.isSymbolicLink()) {
-                    File f = file.toFile();
-                    counters.queuedData.addAndGet(f.length());
-                    tpe.submit(new ProcessTask(BLOCK_SIZE, f, hashes, counters));
+                    counters.queuedData.addAndGet(Files.size(file));
+                    tpe.submit(new ProcessTask(file, hashes, counters));
                 }
                 return FileVisitResult.CONTINUE;
             }


### PR DESCRIPTION
AFAIU creating new ThreadLocal in every task will not cache anything...
Also replaced new FileInputStream with Files.newInputStream to promote its use (it has no finalize(), while FileInputStream does)